### PR TITLE
update yang model in the xml doc

### DIFF
--- a/draft-ietf-asap-sip-auto-peer-16.xml
+++ b/draft-ietf-asap-sip-auto-peer-16.xml
@@ -440,7 +440,7 @@ module ietf-sip-auto-peering {
   revision 2025-01-30 {
     description "Capability set document v2.";
     reference
-      "draft-ietf-asap-sip-auto-peer-14:
+      "draft-ietf-asap-sip-auto-peer-16:
       Automatic Peering for SIP Trunks";
   }
 

--- a/ietf-sip-auto-peering@2025-01-30.yang
+++ b/ietf-sip-auto-peering@2025-01-30.yang
@@ -53,7 +53,7 @@ module ietf-sip-auto-peering {
   revision 2025-01-30 {
     description "Capability set document v2.";
     reference
-      "draft-ietf-asap-sip-auto-peer-14:
+      "draft-ietf-asap-sip-auto-peer-16:
       Automatic Peering for SIP Trunks";
   }
 


### PR DESCRIPTION
Update the new yang model in the xml document and fix the issues with yang validation

```
ietf-sip-auto-peering@2025-01-30.yang:
pyang 2.6.1: pyang --verbose --ietf -p {libs} {model}:
# module search path: /tmp/tmpvnisgzuh:/a/www/ietf-ftp/yang/rfcmod/:/a/www/ietf-ftp/yang/draftmod/:/a/www/ietf-ftp/yang/ianamod/:/a/www/ietf-ftp/yang/catalogmod/:.:/usr/local/share/yang/modules
# read /tmp/tmpvnisgzuh/ietf-sip-auto-peering@2025-01-30.yang (CL)
# read /usr/local/share/yang/modules/ietf/ietf-inet-types.yang
# read /a/www/ietf-ftp/yang/draftmod/ietf-inet-types@2024-10-21.yang
/tmp/tmpvnisgzuh/ietf-sip-auto-peering@2025-01-30.yang:118: error: [RFC 8407](https://datatracker.ietf.org/doc/rfc8407/): 4.10: top-level node peering-info must not be mandatory
```