### PR TITLE
fix unique doc comment

### DIFF
--- a/draft-ietf-asap-sip-auto-peer-19.xml
+++ b/draft-ietf-asap-sip-auto-peer-19.xml
@@ -1032,7 +1032,7 @@ This section provides examples of how capability set documents that
 leverage the YANG module defined in this document can be encoded over
 JSON as well as the exchange of messages between the enterprise
 edge element and the service provider to acquire the capability set
-document. The service provider will create unique documents for each enterprise
+document. The service provider will create a unique document for each enterprise
 network that will peer with it.
 </t>
   <section anchor="json-capability-set-document" 


### PR DESCRIPTION
> As I read this, it seems that the SIP server capabilities is a common
    document served to all SIP enterprise users.   However, tucked into the
    YANG is the numranges to represent the direct inward dial prefixes for the
    client.  If the server is expected to serve different capabilities
    documents to different client, then this should be explained.  (I can see
    that this can be done securely, given the requirements for oAuth
    authentication of the client.)  That would also answer the above question,
    since then presumably the user name and password are specific to the
    client, and only sent via HTTPS to the specific client?  Not sure where
    the4 best place in the document to clarify this would be?   Maybe the
    opening paragraph of 7.3 if not before that?

Added text in section 4.3 and 9 to indicate this.