### PR TITLE
fixed low hanging comments from orie

### DIFF
--- a/draft-ietf-asap-sip-auto-peer-22.xml
+++ b/draft-ietf-asap-sip-auto-peer-22.xml
@@ -1384,7 +1384,7 @@ is encoded in JSON.
 </t>
         <artwork name="" type="" align="left" alt=""><![CDATA[
     HTTP/1.1 200 OK
-    Content-Type: application/peering-info+json
+    Content-Type: application/json
     Content-Length: nnn
 
     {


### PR DESCRIPTION
## Discuss

### Example exchange

```
1828           GET /capdoc?trunkid=trunkent1456 HTTP/1.1
1829           Host: capserver.ssp1.com
1830           Accept:application/peering-info+json
```

`application/peering-info` is not listed in
https://www.iana.org/assignments/media-types/media-types.xhtml

and is not `application/json`.

Is there a missing authorization header in this example?


## Comments

### MIME type

```
478        outlined in section 4.5.  The MIME type for the capability set
479        document defined in this draft is "application/json".  Accordingly,
480        the Accept header field value MUST be restricted only to this MIME
481        type.
```

The modern term for MIME type is "media type". See RFC6838 Section 1.1.

The restriction for the accept header seems not needed for interop as the
server can ignore the accept header, and still always return application/json.

You might consider reframing this as:
This document does not specify any content negotiation.
The server MUST set the response content type header to the application/json
media type.

### Conditional request

```
483        The generated HTTP GET request MUST NOT use the "Expect" and "Range"
484        header fields.  The requests MUST also not use any conditional
485        request.
```

Consider the comment on the conditional request as it relates to the accept
header, and authorization headers and the guidance in section 4.6.

```
545        Capability servers include the capability set documents in the body
546        of a successful response.  Capability set documents MUST be formatted
547        in JSON.  For requests that are incorrectly formatted, the capability
548        server must generate a "400 Bad Request" response.  If the client
549        (enterprise edge element) includes any other MIME types in Accept
550        header field other than "application/json", the capability set must
551        reject the request with a "406 Not Acceptable" response.
```

For a get request, outside of headers, which parameters might a client supply
that would result in the 400?

Consider clarifying that 400 and 406 are http status codes for the response,
and not the response body.

Is the expected content type for responses with status 400 and 406 also
application/json?

Is there a status that is expected to be returned for invalid access tokens?


### Why is SIP-Connect-TR normative?

What parts of it are required to be understood to implement
`draft-ietf-asap-sip-auto-peer` ?


