### PR TITLE
fix amanda iana consid comments

### DIFF
--- a/draft-ietf-asap-sip-auto-peer-38.xml
+++ b/draft-ietf-asap-sip-auto-peer-38.xml
@@ -1700,12 +1700,6 @@ is encoded in JSON.
       update is triggered by an RFC, that RFC must also be included in
       the "reference" substatement.</t>
 
-      <t>-- If a name in the IANA registry does not comply with the
-        -- YANG naming conventions, add details how IANA can generate
-        -- legal identifiers. For example, if the name begins with
-        -- a number, indicate a preference to spell out the number when
-        -- used as an identifier.</t>
-
       <t>IANA is requested to add this note to [reference-to-the-iana-sip-option-tags-
       registry]:</t>
 
@@ -1955,8 +1949,7 @@ module iana-sip-option-tags {
      they appear in all capitals, as shown here.";
 
   reference
-    "Session Initiation Protocol (SIP) Parameters
-     (https://www.iana.org/assignments/sip-parameters/sip-parameters.xhtml)";
+    "RFC XXXX"
 
   revision 2025-12-21 {
     description

--- a/iana-sip-option-tags@2025-12-21.yang
+++ b/iana-sip-option-tags@2025-12-21.yang
@@ -44,10 +44,9 @@ module iana-sip-option-tags {
      they appear in all capitals, as shown here.";
 
   reference
-    "Session Initiation Protocol (SIP) Parameters
-     (https://www.iana.org/assignments/sip-parameters/sip-parameters.xhtml)";
+    "RFC XXXX";
 
-  revision 2025-12-21 {
+  revision 2026-01-07 {
     description
       "Initial revision.";
     reference


### PR DESCRIPTION
1) Section 10.1 appears to contain a chunk of unaltered text from a 8407bis template:

"-- If a name in the IANA registry does not comply with the -- YANG naming conventions, add details how IANA can generate -- legal identifiers. For example, if the name begins with -- a number, indicate a preference to spell out the number when -- used as an identifier."

In fact, the module does include conflicting naming models for IANA. Specifically, two different methods have been used to render "100" and "199" ("one-hundred," "one-nine-nine"). As it stands, IANA will have to ask YANG doctors how to render any future registrations named after multi-digit numbers. (Alternatively, we could ask registry experts, but they may not be familiar with YANG.)

2) I didn't notice this until I'd created the registration: in Section 10, the YANG module name registration for iana-sip-option-tags lists the Option Tags registry itself as the reference for the registration rather than the document. The issue for is that every other IANA-maintained module registration at https://www.iana.org/assignments/yang-parameters lists the document, not the registry, in this field. The registry is instead named in the registration's "Notes" field, where we point out that we can't add new values to the module unless we've added them to the registry. Can this change be made in the document?

OLD: Reference: https://www.iana.org/assignments/sip-parameters/sip-parameters.xhtml
NEW: RFC XXXX
